### PR TITLE
Add Mission List and Mission from API

### DIFF
--- a/src/components/missions/Mission.js
+++ b/src/components/missions/Mission.js
@@ -1,0 +1,16 @@
+import style from './Mission.module.css'
+
+const Mission = (props) => {
+  console.log(props.mission_name)
+  const { mission_id, mission_name, description } = props.mission
+  return (
+    <>
+      <td className={style.border}>{mission_name}</td>
+      <td className={style.border}>{description}</td>
+      <td className={style.border}>NOT A MEMBER</td>
+      <td className={style.border}><button type="button">Join Mission</button></td>
+    </>
+  )
+}
+
+export default Mission

--- a/src/components/missions/Mission.module.css
+++ b/src/components/missions/Mission.module.css
@@ -1,0 +1,3 @@
+.border {
+  border: 1px solid;
+}

--- a/src/components/missions/MissionsList.js
+++ b/src/components/missions/MissionsList.js
@@ -1,5 +1,47 @@
+import { v4 as uuidv4 } from 'uuid';
+import { useState, useEffect } from "react";
+import { useSelector, useDispatch } from "react-redux";
+import { increment, fetchMissions } from "../../redux/features/missions/missionsSlice";
+import Mission from "./Mission";
+import style from './MissionsList.module.css'
+
 const MissionsList = () => {
-  return <h1>Missions</h1>
+  const dispatch = useDispatch();
+  const state = useSelector((state) => state.missions)
+
+
+  useEffect(() => {
+    dispatch(fetchMissions())
+
+  }, [dispatch])
+
+  useEffect(() => {
+    console.log(state.missionsArray)
+
+
+  }, [state])
+
+  if (!state.missionsArray) {
+    return <h1>Loading...</h1>;
+  }
+
+  return (
+    <div>
+      <table className={style.table}>
+        <thead>
+          <tr>
+            <th className={style.border}>Mission</th>
+            <th className={style.border}>Description</th>
+            <th className={style.border}>Status</th>
+            <th className={style.border}></th>
+          </tr>
+        </thead>
+        <tbody>
+          {state.missionsArray.map((mission) => <tr key={uuidv4()}><Mission mission={mission} /></tr>)}
+        </tbody>
+      </table>
+    </div>
+  )
 }
 
 export default MissionsList;

--- a/src/components/missions/MissionsList.module.css
+++ b/src/components/missions/MissionsList.module.css
@@ -1,0 +1,7 @@
+.table {
+  border-collapse: collapse;
+}
+
+.border {
+  border: 1px solid;
+}

--- a/src/redux/app/store.js
+++ b/src/redux/app/store.js
@@ -1,6 +1,7 @@
 import { configureStore } from '@reduxjs/toolkit';
-
+import missionsReducer from '../features/missions/missionsSlice'
 export const store = configureStore({
   reducer: {
+    missions: missionsReducer,
   },
 });

--- a/src/redux/features/missions/missionsSlice.js
+++ b/src/redux/features/missions/missionsSlice.js
@@ -1,0 +1,52 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
+
+const initialState = {
+  missionsArray: null,
+  isLoading: false,
+  isError: false,
+}
+
+export const fetchMissions = createAsyncThunk('get/missions', async () => {
+  const url = 'https://api.spacexdata.com/v3/missions'
+  const response = await fetch(url)
+  return response.json()
+})
+
+export const missionsSlice = createSlice({
+  name: 'Missions',
+  initialState,
+  reducers: {
+    increment: (state) => {
+      state.count += 1
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(fetchMissions.pending, (state) => {
+      return {
+        ...state,
+        isLoading: true,
+      }
+    })
+
+    builder.addCase(fetchMissions.fulfilled, (state, action) => {
+      return {
+        ...state,
+        isLoading: false,
+        missionsArray: action.payload,
+      }
+    })
+
+    builder.addCase(fetchMissions.rejected, (state, action) => {
+      console.log('Error', action.error.message)
+      return {
+        ...state,
+        isError: true,
+        isLoading: false,
+      }
+    })
+  }
+})
+
+export const { increment } = missionsSlice.actions;
+
+export default missionsSlice.reducer;


### PR DESCRIPTION
In this PR I fulfilled the following tasks:
- [x] Fetch data from the Missions endpoint (https://api.spacexdata.com/v3/missions) when a user navigates to the Missions section.
- [x] Once the data are fetched, dispatch an action to store the selected data in Redux store:
- mission_id
- mission_name
- description
- [x] Only dispatch fetch mission action one time
- [x] Use useSelector() Redux Hook to select the state slices and render lists of missions in corresponding routes
- [x] Render a table with the missions' data (as per design).